### PR TITLE
Ensure compatibility with Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "require": {
         "nimbusoft/flysystem-openstack-swift": "^0.3",
         "biigle/laravel-cached-openstack": "^1.0",
-        "illuminate/support": "^5.1|^6.0",
-        "illuminate/filesystem": "^5.1|^6.0"
+        "illuminate/support": "^5.1|^6.0|^7.0",
+        "illuminate/filesystem": "^5.1|^6.0|^7.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Regarding issue #2 this pull request extends the composer requirements so Laravel 7 installations can require and install this package.

I've tested the basic functionality to ensure that the package is still working on the Laravel 7 code base and so far everything seems fine.